### PR TITLE
Adding .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/*
+package-lock.json


### PR DESCRIPTION
Adds 

node_modules/*
package-lock.json

to .gitignore to avoid having vscode try and track these files.